### PR TITLE
Fixed Ubuntu package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ This will make and run all the tests
 The packages required in Ubuntu include:
 
 ```shell
-cmake libsdl2-dev libsdl2-image-dev libsdl2-tff-dev libsdl2-gfx-dev
+cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-gfx-dev
 ```


### PR DESCRIPTION
`libsdl2-ttf-dev` is required, not `libsdl2-tff-dev`